### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Fully white-labelled UI/UX paired up to Torus PKI and auth for React Native.
 
 This SDK requires native modules and is designed to bring native experience to your React Native app without you doing any work.
 
-If you've already implemented a native auth experience or prefer to use plain JS React Native, you can use [customauth-web-sdk](https://github.com/torusresearch/customauth-web-sdk), which won't require native modules and can plug into your login system via `getTorusKey` and `getAggregateTorusKey` function.
-
 ## Getting Started
 
 ```bash
@@ -23,31 +21,44 @@ Please refer to the native SDKs for platform-specific configuration.
 
 #### iOS
 
-1. In Xcode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
-2. Go to `node_modules` ➜ `@toruslabs/customauth-react-native-sdk` and add `RNCustomAuthSdk.xcodeproj`
-3. In Xcode, in the project navigator, select your project. Add `libRNCustomAuthSdk.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
-4. Run your project `Cmd+R`
+1. Add the following to your `Podfile` then run `pod install` from the `ios` directory:
+```ruby
+pod 'CustomAuth', '~> 2.1.0', :modular_headers => true
+pod 'secp256k1.swift', :modular_headers => true
+```
+2. Open Xcode, in the project navigator, select your project. Add `libRNCustomAuthSdk.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
+3. Run your project `Cmd+R`
 
 #### Android
 
-1. Open up `android/app/src/main/java/[...]/MainActivity.java`
-
-   - Add `import org.torusresearch.rncustomauth.RNCustomAuthSdkPackage;` to the imports at the top of the file
-
-   - Add `new RNCustomAuthSdkPackage()` to the list returned by the `getPackages()` method
-
+1. Add `maven { url "https://jitpack.io" }` to the repositories block of `android/build.gradle`
 2. Append the following lines to `android/settings.gradle`:
 
    ```groovy
    include ':customauth-react-native-sdk'
-   project(':customauth-react-native-sdk').projectDir = new File(rootProject.projectDir, '../node_modules/customauth-react-native-sdk/android')
+   project(':customauth-react-native-sdk').projectDir = new File(rootProject.projectDir, '../node_modules/@toruslabs/customauth-react-native-sdk/android')
    ```
 
 3. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
 
    ```groovy
-   compile project(':customauth-react-native-sdk')
+   implementation project(':customauth-react-native-sdk')
    ```
+
+4. Add the following to `android/app/build.grade`
+  ```groovy
+  android {
+    ...
+    defaultConfig {
+      manifestPlaceholders = [
+            //... other placeholders if you have them
+            'torusRedirectScheme': 'torusapp',
+            'torusRedirectHost': 'org.torusresearch.customauthandroid',
+            'torusRedirectPathPrefix': '/redirect'
+        ]
+    }
+  }
+  ```
 
 ## Usage
 
@@ -99,6 +110,23 @@ Add the following snipplet to your `ios/Podfile`. See `example2/ios/Podfile` for
   end
 ```
 
-This is a temporary mitigation for broken xcconfig in the podspec of web3.swift. You may know more at https://github.com/argentlabs/web3.swift/pull/161.
+This is a temporary mitigation for broken xcconfig in the podspec of web3.swift. You may know more at https://github.com/argentlabs/web3.swift/pull/161. If you are using web3.swift >= 0.8.2 this should be fixed.
 
 Want to know more or implement more advanced use cases? See our [API reference](https://docs.tor.us/customauth/api-reference/usage).
+
+2. I got an error on my android build similar to `Failed to transform bcprov-jdk15on-1.68.jar`
+
+Add the following to `android/app/build.gradle` in the `android` block:
+
+```groovy
+android {
+  //All other config in the android block should be above this
+  configurations {
+    all*.exclude module: 'bcprov-jdk15on'
+  }
+}
+```
+and add the following to `gradle.properties`:
+```
+android.jetifier.blacklist=bcprov
+```


### PR DESCRIPTION
The steps in the README are a little out of date for where the package is now, and can send some one down the wrong path.

These changes are from getting this sdk working in our react native project with package version `1.0.2` in react-native `0.65.1`.

I removed the web sdk suggestion because I tried it prior to installing this package and it failed when initializing. I found that it depends on the default behavior of node/browsers, which is not actually the environment react-native runs in, and without changes that library will crash when you try to use it currently. I was not able to fix these errors because they ended up in minified code so I tried this package instead.